### PR TITLE
Fix duplicate timer creation

### DIFF
--- a/Sources/PopoverViewController.swift
+++ b/Sources/PopoverViewController.swift
@@ -25,7 +25,6 @@ class PopoverViewController: NSViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupUI()
         setupUpdateTimer()
     }
     
@@ -101,13 +100,6 @@ class PopoverViewController: NSViewController {
         contentView.addSubview(quitButton)
         
         self.view = contentView
-    }
-    
-    private func setupUI() {
-        // Update motion data every second (1 Hz display rate)
-        updateTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.updateMotionDisplay()
-        }
     }
     
     private func setupUpdateTimer() {


### PR DESCRIPTION
## Summary
- fix redundant timer setup in `PopoverViewController`

## Testing
- `swift test` *(fails: no such module 'Cocoa')*

------
https://chatgpt.com/codex/tasks/task_e_683fe46f25208331b9a18a6bb2d3be6b